### PR TITLE
Adding CUDA 10.1 support for focal

### DIFF
--- a/debian/focal/system76-cuda-10.1/changelog
+++ b/debian/focal/system76-cuda-10.1/changelog
@@ -1,0 +1,5 @@
+system76-cuda-10.1 (0pop0) focal; urgency=medium
+
+  * Initial release.
+
+ -- acxz <akashpatel2008@yahoo.com>  Thu, 28 May 2020 09:35:22 -0700

--- a/debian/focal/system76-cuda-10.1/control
+++ b/debian/focal/system76-cuda-10.1/control
@@ -1,0 +1,19 @@
+Source: system76-cuda-10.1
+Maintainer: Michael Aaron Murphy <michael@system76.com>
+Standards-Version: 4.1.1
+Priority: optional
+Section: devel
+Build-Depends:
+    ca-certificates,
+    debhelper (>= 9),
+    g++-8,
+    ssl-cert,
+    wget,
+
+Package: system76-cuda-10.1
+Description: NVIDIA CUDA 10 Compiler / Libraries / Toolkit
+Architecture: amd64
+Section: devel
+Depends:
+    system76-cuda,
+    ${misc:Depends},

--- a/debian/focal/system76-cuda-10.1/postinst
+++ b/debian/focal/system76-cuda-10.1/postinst
@@ -1,0 +1,3 @@
+#!/bin/sh
+update-alternatives --install /usr/lib/cuda cuda /usr/lib/cuda-10.1 100
+ldconfig

--- a/debian/focal/system76-cuda-10.1/rules
+++ b/debian/focal/system76-cuda-10.1/rules
@@ -1,0 +1,19 @@
+#!/usr/bin/make -f
+
+export CUDA_VERSION=10.1
+export DESTDIR=$(PWD)/debian/tmp
+export CC=/usr/bin/gcc-8
+export CXX=/usr/bin/g++-8
+
+%:
+	dh $@
+
+override_dh_auto_build:
+	make \
+		INSTALLER=cuda_10.1.105_418.39_linux.run \
+		INSTALLER_SUM=4be516e493ef9588f455df0722e2e686
+
+# CUDA ships its own shared libraries
+override_dh_shlibdeps:
+
+override_dh_strip:

--- a/debian/focal/system76-cudnn-10.1/changelog
+++ b/debian/focal/system76-cudnn-10.1/changelog
@@ -1,0 +1,5 @@
+system76-cudnn-10.1 (7.6.5) focal; urgency=medium
+
+  * Initial release.
+
+ -- acxz <akashpatel2008@yahoo.com>  Thu, 28 May 2020 10:08:11 -0700

--- a/debian/focal/system76-cudnn-10.1/control
+++ b/debian/focal/system76-cudnn-10.1/control
@@ -1,0 +1,14 @@
+Source: system76-cudnn-10.1
+Maintainer: Michael Aaron Murphy <michael@system76.com>
+Standards-Version: 4.1.1
+Priority: optional
+Section: devel
+Build-Depends: debhelper (>= 9)
+
+Package: system76-cudnn-10.1
+Description: NVIDIA CUDA Deep Neural Network library (cuDNN) for CUDA 10.1
+Architecture: amd64
+Section: devel
+Depends:
+    system76-cuda-10.1,
+    ${misc:Depends},

--- a/debian/focal/system76-cudnn-10.1/install
+++ b/debian/focal/system76-cudnn-10.1/install
@@ -1,0 +1,1 @@
+cuda/*    /usr/lib/cuda-10.1/

--- a/debian/focal/system76-cudnn-10.1/rules
+++ b/debian/focal/system76-cudnn-10.1/rules
@@ -1,0 +1,12 @@
+#!/usr/bin/make -f
+
+CUDA_VERSION=10.1
+PREFIX=usr/lib/cuda-$(CUDA_VERSION)
+
+%:
+	dh $@
+
+override_dh_auto_build:
+
+override_dh_auto_install:
+	tar xvf cudnn.tgz

--- a/debian/focal/system76-nccl-10.1/changelog
+++ b/debian/focal/system76-nccl-10.1/changelog
@@ -1,0 +1,5 @@
+system76-nccl-10.1 (2.5.6-2) focal; urgency=medium
+
+  * Initial release.
+
+ -- Marcus Loo <slayer71432@gmail.com>  Thu, 28 May 2020 10:08:11 -0700

--- a/debian/focal/system76-nccl-10.1/control
+++ b/debian/focal/system76-nccl-10.1/control
@@ -1,0 +1,21 @@
+Source: system76-nccl-10.1
+Maintainer: Michael Aaron Murphy <michael@system76.com>
+Standards-Version: 4.1.1
+Priority: optional
+Section: devel
+Build-Depends:
+    debhelper (>= 9),
+    build-essential,
+    g++-8,
+    system76-cuda-10.1,
+    unzip,
+
+Package: system76-nccl-10.1
+Description: Optimized primitives for collective multi-GPU communication.
+Architecture: amd64
+Section: devel
+Depends:
+    build-essential,
+    g++-8,
+    system76-cuda-10.1,
+    ${misc:Depends},

--- a/debian/focal/system76-nccl-10.1/install
+++ b/debian/focal/system76-nccl-10.1/install
@@ -1,0 +1,1 @@
+usr/lib/cuda-10.1/

--- a/debian/focal/system76-nccl-10.1/rules
+++ b/debian/focal/system76-nccl-10.1/rules
@@ -1,0 +1,20 @@
+#!/usr/bin/make -f
+
+CUDA_SDK=usr/lib/cuda-10.1/
+export CC=/usr/bin/gcc-8
+export CXX=/usr/bin/g++-8
+
+%:
+	dh $@
+
+override_dh_auto_build:
+	make -j src.build CUDA_HOME=/$(CUDA_SDK)
+
+override_dh_auto_install:
+	mkdir -p $(CUDA_SDK)/lib64 $(CUDA_SDK)/include
+	mv build/lib/* $(CUDA_SDK)/lib64
+	mv build/include/* $(CUDA_SDK)/include/
+
+override_dh_strip:
+
+override_dh_shlibdeps:

--- a/suites/focal.toml
+++ b/suites/focal.toml
@@ -45,6 +45,37 @@ depends = [
     checksum = "8a30e0b4813a825592872fcbeeede22a659e2c399074dcce02960591dc81387d"
 
 [[source]]
+name = "system76-cuda-10.1"
+build_on = "changelog"
+keep_source = false
+retain = 1
+assets = [
+    { src = "cuda_makefile", dst = "Makefile" },
+    { src = "nvidia_cuda/*", dst = "debian" }
+]
+
+[[source]]
+name = "system76-cudnn-10.1"
+build_on = "changelog"
+assets = [
+    { src = "nvidia_cuda/*", dst = "debian" }
+]
+retain = 1
+keep_source = false
+
+[[source]]
+name = "system76-nccl-10.1"
+build_on = "changelog"
+depends = [
+    "system76-cuda",
+    "system76-cuda-10.1",
+]
+
+    [source.location]
+    url = "https://github.com/NVIDIA/nccl/archive/v2.5.6-2.tar.gz"
+    checksum = "8a30e0b4813a825592872fcbeeede22a659e2c399074dcce02960591dc81387d"
+
+[[source]]
 name = "system76-cuda-10.2"
 build_on = "changelog"
 keep_source = false


### PR DESCRIPTION
There seems to be 10.1 support for bionic, but not focal. 
@acxz and I worked on adding this support for focal, and this should resolves #14 

List of files to change for focal

- [x] https://github.com/mloo3/cuda/blob/master/suites/focal.toml
- [x] focal ver of: https://github.com/mloo3/cuda/tree/master/debian/bionic/system76-cuda-10.1 
- [x] focal ver of: https://github.com/mloo3/cuda/tree/master/debian/bionic/system76-nccl-10.1 
- [x] focal ver of: https://github.com/mloo3/cuda/tree/master/debian/bionic/system76-cudnn-10.1 
