### PR TITLE
Creation of the system76-cudnn-latest metapackage

### DIFF
--- a/metapackages/focal/system76-cudnn-latest.cfg
+++ b/metapackages/focal/system76-cudnn-latest.cfg
@@ -1,0 +1,9 @@
+Section: metapackages
+Priority: optional
+Homepage: https://developer.nvidia.com/cudnn
+Standards-Version: 3.9.2
+Package: system76-cuda-latest
+Version: 11.1~20.04
+Maintainer: Michael Aaron Murphy <michael@system76.com>
+Depends: system76-cudnn-11.1
+Description: Metapackage for the latest version of the cuDNN Library

--- a/metapackages/groovy/system76-cudnn-latest.cfg
+++ b/metapackages/groovy/system76-cudnn-latest.cfg
@@ -1,0 +1,9 @@
+Section: metapackages
+Priority: optional
+Homepage: https://developer.nvidia.com/cudnn
+Standards-Version: 3.9.2
+Package: system76-cuda-latest
+Version: 11.1~20.10
+Maintainer: Michael Aaron Murphy <michael@system76.com>
+Depends: system76-cudnn-11.1
+Description: Metapackage for the latest version of the cuDNN Library


### PR DESCRIPTION
I think is necessary a cuDNN meta-package since the cuda article needs to be periodically updated each time a new cuDNN is added, and since a cuDNN version require the installation of the compatible version of cuda this leads to extra version of cuda installed. 

Having this new meta-package along with the already existing system76-cuda-latest meta-package we could save the user unnecessary  installation of other versions of CUDA when installing the cuDNN library. 

Check issue from docs/article/cuda:
https://github.com/system76/docs/issues/531